### PR TITLE
Title fix

### DIFF
--- a/apps/pr_web/lib/pr_web/live/playback_live.ex
+++ b/apps/pr_web/lib/pr_web/live/playback_live.ex
@@ -140,7 +140,7 @@ defmodule PRWeb.PlaybackLive do
   defp page_title(%PlaybackState{state: :idle}), do: PRWeb.SharedView.installation_name()
   defp page_title(%PlaybackState{state: :playing}), do: :metadata |> PlayState.get() |> page_title()
   defp page_title(%{current_item: %SonosItem{name: name, artist: artist}}) do
-    case PlayState.get(:state) do
+    case PlayState.get(:play_state) do
       %PlaybackState{state: :playing} ->
         "🎵 #{name} – #{artist}"
       _ ->


### PR DESCRIPTION
Show the title only if its playing. Otherwise it shows the title of whatever the (sonos) player is idling on