### PR TITLE
retry retries

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,7 +14,8 @@ config :pr,
   ecto_repos: [PR.Repo],
   playlist_name: "PlayRequest",
   timezone: "Europe/London",
-  env: config_env()
+  env: config_env(),
+  sleep: 10_000
 
 # Configures the endpoint
 config :pr, PRWeb.Endpoint,

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,7 +15,7 @@ config :pr,
   playlist_name: "PlayRequest",
   timezone: "Europe/London",
   env: config_env(),
-  sleep: 10_000
+  sleep: 5_000
 
 # Configures the endpoint
 config :pr, PRWeb.Endpoint,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,3 +11,6 @@ config :pr, PRWeb.Endpoint,
   server: true,
   root: ".",
   version: Application.spec(:pr, :vsn)
+
+config :pr,
+  sleep: 20_000

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,8 @@
 import Config
 
 config :pr,
-  allowed_user_domains: "example.com"
+  allowed_user_domains: "example.com",
+  sleep: 0
 
 # Configure your database
 config :pr, PR.Repo,

--- a/lib/pr/sonos_households/group_manager.ex
+++ b/lib/pr/sonos_households/group_manager.ex
@@ -7,7 +7,7 @@ defmodule PR.SonosHouseholds.GroupManager do
 
   @retries 5
 
-  def check_groups do
+  def check_groups() do
     # Fetch groups from SonosAPI look for one that has the same name as the one that's stored
     # If not, the players may have become un-grouped, so create and save a new group with the
     # player ids that we had before.
@@ -131,7 +131,7 @@ defmodule PR.SonosHouseholds.GroupManager do
   end
 
   @spec get_active_group() :: {:ok, String.t(), List.t()} | {:error, atom()}
-  def get_active_group do
+  defp get_active_group do
     # Get Group ID and expected player_ids from the database
     case SonosHouseholds.get_active_group() do
       %Group{id: active_group_id, name: name, player_ids: player_ids} ->

--- a/lib/pr/worker/group_check.ex
+++ b/lib/pr/worker/group_check.ex
@@ -1,0 +1,50 @@
+defmodule PR.Worker.GroupCheck do
+  require Logger
+  use GenServer
+
+  alias PR.SonosHouseholds.GroupManager
+
+  def start_link(default) when is_list(default) do
+    GenServer.start_link(__MODULE__, default)
+  end
+
+  @impl true
+  def init(state) do
+    schedule_retry(0)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:retry, [_, 0] = state) do
+    Logger.info("GroupCheck retries exhausted")
+    {:stop, :normal, state}
+  end
+
+  def handle_info(:retry, [group, retries] = state) do
+    case GroupManager.check_or_recrate_active_group(group, retries) do
+      :ok ->
+        Logger.info("GroupCheck ok, no retry")
+        {:stop, :normal, state}
+
+      {:retry, group, retries} ->
+        Logger.info("GroupCheck retry: #{retries}")
+
+        get_wait()
+        |> schedule_retry()
+
+        {:noreply, [group, retries]}
+
+      _ ->
+        Logger.info("GroupCheck error, no retry")
+        {:noreply, state}
+    end
+  end
+
+  defp schedule_retry(wait) do
+    Process.send_after(self(), :retry, wait)
+  end
+
+  defp get_wait() do
+    Application.get_env(:pr, :sleep)
+  end
+end


### PR DESCRIPTION
- Not sure if it's running anything after sleep()
- Maybe make a group check supervisor or something to do the retries in a genserver
- Manually running check_groups after a while seems to solve the group gone issue
- Might need an oplock on the handler, cos it seems to fire twice. i think as 2 webhooks. could be multiple subscriptions or something