### PR TITLE
Sign user socket token in AuthHooks for LiveView routes

### DIFF
--- a/lib/pr_web/live/auth_hooks.ex
+++ b/lib/pr_web/live/auth_hooks.ex
@@ -31,7 +31,7 @@ defmodule PRWeb.AuthHooks do
         {:cont,
          socket
          |> assign(current_user: user)
-         |> assign(user_token: Phoenix.Token.sign(socket, "user socket", user.id))}
+         |> assign(user_token: PRWeb.UserSocketToken.sign(socket, user.id))}
     end
   end
 

--- a/lib/pr_web/live/auth_hooks.ex
+++ b/lib/pr_web/live/auth_hooks.ex
@@ -27,7 +27,11 @@ defmodule PRWeb.AuthHooks do
 
       user ->
         Logger.debug("AuthHook: User authenticated: #{inspect(user.id)}")
-        {:cont, assign(socket, current_user: user)}
+
+        {:cont,
+         socket
+         |> assign(current_user: user)
+         |> assign(user_token: Phoenix.Token.sign(socket, "user socket", user.id))}
     end
   end
 

--- a/lib/pr_web/plugs/user_socket_token.ex
+++ b/lib/pr_web/plugs/user_socket_token.ex
@@ -7,7 +7,7 @@ defmodule PRWeb.Plug.UserSocketToken do
 
   def call(conn, _) do
     if current_user = conn.assigns[:current_user] do
-      token = Phoenix.Token.sign(conn, "user socket", current_user.id)
+      token = PRWeb.UserSocketToken.sign(conn, current_user.id)
       assign(conn, :user_token, token)
     else
       conn

--- a/lib/pr_web/user_socket.ex
+++ b/lib/pr_web/user_socket.ex
@@ -5,8 +5,7 @@ defmodule PRWeb.UserSocket do
   channel("notifications:*", PRWeb.NotificationsChannel)
 
   def connect(%{"token" => token}, socket, _connect_info) do
-    # max_age: 1209600 is equivalent to two weeks in seconds
-    case Phoenix.Token.verify(socket, "user socket", token, max_age: 1_209_600) do
+    case PRWeb.UserSocketToken.verify(socket, token) do
       {:ok, user_id} ->
         {:ok, assign(socket, :user_id, user_id)}
 

--- a/lib/pr_web/user_socket_token.ex
+++ b/lib/pr_web/user_socket_token.ex
@@ -1,0 +1,14 @@
+defmodule PRWeb.UserSocketToken do
+  @moduledoc """
+  Signing and verification of the token used to authenticate the user socket.
+  """
+
+  @salt "user socket"
+  # Two weeks in seconds
+  @max_age 1_209_600
+
+  def sign(context, user_id), do: Phoenix.Token.sign(context, @salt, user_id)
+
+  def verify(context, token),
+    do: Phoenix.Token.verify(context, @salt, token, max_age: @max_age)
+end


### PR DESCRIPTION
The Phoenix 1.8 upgrade (b34418b) moved / from the :auth plug pipeline
to a live_session with AuthHooks. That dropped PRWeb.Plug.UserSocketToken,
so window.userToken was empty and notifications.js never connected to
the /socket websocket. Sign the token in on_mount so the root layout
renders it on the dead render.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
