### PR TITLE
Provider abstraction + provider-agnostic track ids

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,13 @@
   "permissions": {
     "allow": [
       "Bash(mix compile:*)",
-      "Bash(mix test *)"
+      "Bash(mix test *)",
+      "Bash(fly status *)",
+      "Bash(fly volumes *)",
+      "Bash(fly machines *)",
+      "Bash(fly secrets *)",
+      "Bash(fly ssh *)",
+      "Bash(fly machine *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,11 @@
 {
-  "env": { "ENABLE_LSP_TOOL": "1" },
+  "env": {
+    "ENABLE_LSP_TOOL": "1"
+  },
   "permissions": {
-    "allow": ["Bash(mix compile:*)"]
+    "allow": [
+      "Bash(mix compile:*)",
+      "Bash(mix test *)"
+    ]
   }
 }

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -185,5 +185,5 @@ jobs:
             -d "token=${{ secrets.PUSHOVER_KEY }}" \
             -d "user=${{ secrets.PUSHOVER_USER }}" \
             -d "title=SonoNow Staging Deployed" \
-            -d "message=Version ${{ github.ref_name }} deployed to production" \
+            -d "message=Version ${{ github.ref_name }} deployed to staging" \
             -d "url=https://sonosnow-staging.fly.dev"

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,6 +13,7 @@ import Config
 config :pr,
   ecto_repos: [PR.Repo],
   playlist_name: "PlayRequest",
+  default_provider: "spotify",
   timezone: "Europe/London",
   env: config_env(),
   sleep: 5_000

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,346 @@
+# How PlayRequest Works
+
+PlayRequest is a shared "social jukebox". People queue Spotify tracks from their
+phones, and the tracks play out of a set of Sonos speakers. Neither Spotify nor
+Sonos offers a single API for "play this list of track IDs on these speakers", so
+the system stitches together three things that they *do* expose:
+
+1. A local, database-backed queue (the source of truth).
+2. A Spotify playlist (kept in sync with the unplayed part of the queue).
+3. A Sonos "favourite" that points at that playlist, triggered to play via the
+   Sonos Control API, with playback events fed back in over a webhook.
+
+This document explains how those pieces fit together, with references to the code
+and the actual API calls involved.
+
+---
+
+## The core idea
+
+```
+  Users (LiveView)                 PlayRequest (Elixir/Phoenix)                 Cloud APIs
+  ----------------                 ----------------------------                 ----------
+  queue a track  ───────────────▶  tracks table (DB queue)
+                                          │
+                                          │ sync unplayed tracks
+                                          ▼
+                                   Spotify playlist  ──── PUT /playlists/{id}/tracks ───▶ Spotify
+                                          │
+                                          │ playlist is saved as a Sonos "favourite"
+                                          ▼
+                                   trigger playback ──── POST /groups/{gid}/favorites ──▶ Sonos
+                                          │
+        update UI  ◀──── PubSub ◀──── webhook  ◀──── POST /sonos/callback ◀───────────── Sonos
+                                   (mark track played in DB)
+```
+
+The **database queue is the source of truth.** The Spotify playlist is a derived,
+disposable projection of it (only the unplayed tracks). Sonos is told to play that
+playlist, and Sonos tells us back what it is actually playing so we can mark tracks
+as played.
+
+---
+
+## 1. The database queue
+
+**Schema:** `PR.Queue.Track` - `lib/pr/queue/track.ex`
+**Context:** `PR.Queue` - `lib/pr/queue/queue.ex`
+
+Each queued track is a row in the `tracks` table. The important fields:
+
+```elixir
+field(:spotify_id, :string)          # Spotify track id; unique
+field(:playing_since, :utc_datetime) # set when Sonos starts playing it
+field(:played_at, :utc_datetime)     # set when it has finished / been superseded
+belongs_to(:user, User)              # who queued it
+```
+
+A track's lifecycle is expressed entirely by those two timestamps:
+
+- `playing_since == nil` and `played_at == nil` -> waiting in the queue
+- `playing_since` set, `played_at == nil` -> currently playing
+- `played_at` set -> done
+
+A unique constraint (`unique_constraint(:spotify_id, name: :already_queued)`)
+stops the same track being queued twice.
+
+The "unplayed queue", used to build the Spotify playlist, is just:
+
+```elixir
+def list_track_uris do
+  Track
+  |> query_unplayed()      # WHERE played_at IS NULL
+  |> order()               # ORDER BY inserted_at ASC
+  |> limit(100)
+  |> select([t], {t.spotify_id})
+  |> Repo.all()
+end
+```
+
+---
+
+## 2. Queueing a track
+
+**Module:** `PR.Music.queue/2` - `lib/pr/music/music.ex:39`
+
+When a user queues a track from the LiveView, the flow is:
+
+1. Fetch full track metadata from Spotify: `SpotifyAPI.get_track(id)`
+   -> `GET https://api.spotify.com/v1/tracks/{id}`
+2. Insert it into the DB queue: `Queue.create_track/1`
+3. Broadcast `queue_updated()` over PubSub so every connected browser refreshes.
+4. Decide what to do next based on whether music is already playing:
+
+```elixir
+if PlayState.is_idle?() do
+  trigger_playlist()   # nothing playing: sync + start Sonos playback
+else
+  sync_playlist()      # already playing: just update the Spotify playlist
+end
+```
+
+So queueing while music is playing only re-syncs the playlist (the new track
+appears at the end). Queueing while idle kicks off the full "start playing"
+pipeline described in section 4.
+
+Searching for tracks works the same way:
+`SpotifyAPI.search(q)` -> `GET /v1/search/?q={q}&type=track&market=GB&limit=10`.
+
+---
+
+## 3. Syncing the queue to the Spotify playlist
+
+**Module:** `PR.Music.sync_playlist/0` - `lib/pr/music/music.ex:61`
+
+This is the heart of the workaround. Whenever the queue changes, the unplayed
+tracks are pushed into a single Spotify playlist, **replacing** its entire
+contents:
+
+```elixir
+def sync_playlist do
+  Queue.list_track_uris()
+  |> Enum.map(fn {id} -> "spotify:track:" <> id end)
+  |> SpotifyAPI.replace_playlist()
+  {:ok}
+end
+```
+
+`SpotifyAPI.replace_playlist/1` (`lib/pr/apis/spotify_api.ex`) does:
+
+```
+PUT https://api.spotify.com/v1/playlists/{playlist_id}/tracks
+body: { "uris": ["spotify:track:abc", "spotify:track:def", ...] }
+```
+
+Using `PUT .../tracks` (replace) rather than `POST` (append) is what keeps the
+playlist an exact mirror of the unplayed queue - already-played tracks drop off,
+and the order matches `inserted_at`. The playlist itself is created once via
+`POST /v1/users/{spotify_id}/playlists` (`{name, public: false}`).
+
+`sync_playlist/0` is called from several places, all of which represent "the queue
+changed":
+
+- when a track is queued while playing (`music.ex:52`)
+- as the first step of `trigger_playlist/1` (`music.ex:80`)
+- on skip (`Music.skip/1`)
+- manually from the setup screen (`POST /setup/sync-playlist`)
+
+---
+
+## 4. Triggering playback on Sonos
+
+**Module:** `PR.Music.trigger_playlist/1` - `lib/pr/music/music.ex:79`
+
+To actually make sound come out, the Spotify playlist must be saved as a Sonos
+"favourite" (done once, manually, in the Sonos app). PlayRequest then tells Sonos
+to play that favourite. The pipeline:
+
+```elixir
+with {:ok} <- sync_playlist(),                                  # 1. refresh Spotify playlist
+     {:ok} <- check_unplayed(),                                 # 2. anything to play?
+     %Group{group_id: group_id} <- SonosHouseholds.get_active_group!(),
+     {:ok, %{items: sonos_favorites}, _} <- SonosAPI.get_favorites(),  # 3. list favourites
+     {:ok, fav_id} <- find_playlist(sonos_favorites),           # 4. find ours by name
+     {:ok} <- check_current_playstate(PlayState.get(:play_state), force),
+     %{} <- SonosAPI.set_favorite(fav_id, group_id) do          # 5. play it
+  {:ok}
+end
+```
+
+The two Sonos calls (`lib/pr/apis/sonos_api.ex`):
+
+```
+GET  https://api.ws.sonos.com/control/api/v1/households/{household_id}/favorites
+POST https://api.ws.sonos.com/control/api/v1/groups/{group_id}/favorites
+     body: { "favoriteId": <id>, "playOnCompletion": true }
+```
+
+`set_favorite/2` is the call that loads the playlist into the group's queue and
+starts it (`playOnCompletion: true`). The favourite is matched by name via
+`find_playlist/1`, so the Sonos favourite must be named to match
+`get_playlist_name()`.
+
+The `check_current_playstate/2` guard prevents clobbering music that is already
+playing: normally it only proceeds when the player is `idle` or `paused`. Skips
+pass `:force` to override this.
+
+---
+
+## 5. The Sonos webhook (feedback loop)
+
+**Route:** `POST /sonos/callback` - `lib/pr_web/router.ex`
+**Controller:** `PRWeb.Service.SonosWebhookController` - `lib/pr_web/controllers/service/sonos_webhook_controller.ex`
+**Logic:** `PR.PlayState` - `lib/pr/play_state.ex`
+
+PlayRequest never polls Sonos for "what's playing". Instead it subscribes to Sonos
+event subscriptions and Sonos POSTs events back. Subscriptions are set up at
+startup (`SonosAPI.subscribe_webhooks/0`):
+
+```
+POST .../groups/{group_id}/playback/subscription          # play/pause/idle changes
+POST .../groups/{group_id}/playbackMetadata/subscription  # current-track changes
+```
+
+Each incoming event carries the group id in the `x-sonos-target-value` header, and
+the controller dispatches on the JSON body shape:
+
+| Body contains   | Handler                          | Meaning                       |
+|-----------------|----------------------------------|-------------------------------|
+| `playbackState` | `handle_play_state_webhook`      | playing / paused / idle       |
+| `currentItem`   | `handle_metadata_webhook`        | the track changed             |
+| `errorCode`     | `handle_error_webhook`           | playback error                |
+| `groupStatus`   | `handle_group_status_webhook`    | group changed / players gone  |
+
+The controller always replies `202` immediately and processes asynchronously.
+
+### Marking a track as played
+
+The key feedback is the **metadata** event ("the track changed"). When Sonos
+reports a new current item, `PlayState.process_metadata/1` calls
+`Queue.set_current/1` (`lib/pr/queue/queue.ex`), which runs a transaction:
+
+```elixir
+# any other track currently marked playing -> mark it played
+Track
+|> query_is_playing()
+|> where([t], t.spotify_id != ^spotify_id)
+|> Repo.update_all(set: [playing_since: nil, played_at: now])
+
+# the new current track -> mark it playing
+Track
+|> where([t], t.spotify_id == ^spotify_id)
+|> where([t], is_nil(t.played_at))
+|> Repo.update_all(set: [playing_since: now])
+```
+
+So "track N started" is what marks "track N-1 finished". Because the queue has now
+changed (a track moved from unplayed to played), the UI is re-broadcast.
+
+### When the player goes idle
+
+If a `playbackState` event reports the group has gone idle but there are still
+unplayed tracks (e.g. Sonos reached the end of the favourite before the playlist
+sync caught up), `PlayState` re-runs `trigger_playlist/1` to keep things going.
+
+---
+
+## 6. Authentication (both services)
+
+Both Spotify and Sonos use OAuth2 authorization-code flow. The token-handling
+logic is shared via a macro: `lib/pr/apis/macros/token_helper.ex`, and tokens are
+stored in the `tokens` table (`PR.ExternalAuth` / `lib/pr/external_auth/`):
+
+```elixir
+field(:access_token, :string)
+field(:refresh_token, :string)
+field(:service, :string)        # "Elixir.PR.SpotifyAPI" or "Elixir.PR.SonosAPI"
+field(:activated_at, :utc_datetime)
+```
+
+| | Spotify | Sonos |
+|---|---|---|
+| Authorize URL | `accounts.spotify.com/authorize` | `api.sonos.com/login/v3/oauth` |
+| Token URL | `accounts.spotify.com/api/token` | `api.sonos.com/login/v3/oauth/access` |
+| Redirect route | `POST /authorized/spotify` | `GET /sonos/authorized` |
+| Scopes | playback + playlist modify/read | `playback-control-all` |
+
+The OAuth callback is handled by `PRWeb.Service.ServiceAuthController`, which calls
+`<Api>.handle_auth_callback/1` to exchange the code for tokens and persist them.
+
+Access tokens are cached in an Agent and refreshed automatically: the shared HTTP
+layer (`lib/pr/apis/macros/endpoint_helper.ex`) detects a `401`, performs a refresh
+(`grant_type=refresh_token` against the token URL), and retries the request. If the
+refresh token itself is rejected, the stored token is discarded and the service
+must be re-authorised from the setup screen.
+
+---
+
+## 7. Sonos households and groups
+
+Sonos organises speakers into a **household** containing **groups** of players.
+PlayRequest discovers and stores these (`PR.SonosHouseholds`,
+`lib/pr/sonos_households/`):
+
+```
+GET .../households                        -> save household ids
+GET .../households/{household_id}/groups  -> save groups (group_id, player_ids)
+```
+
+One group is marked active; that `group_id` is what all the playback calls target.
+Groups are ephemeral on Sonos - if speakers are regrouped, the saved `group_id`
+disappears. `PR.SonosHouseholds.GroupManager` (and the `GroupCheck` worker) checks
+the active group still exists and, if not, recreates one spanning all available
+players via `POST .../households/{household_id}/groups/createGroup`, then
+re-subscribes the webhooks.
+
+---
+
+## 8. Background processes
+
+Supervised in `PR.Application` (`lib/pr/application.ex`):
+
+| Process | Kind | Role |
+|---|---|---|
+| `PR.PlayState` | Agent | Holds current play state / metadata / progress; receives webhooks; broadcasts to LiveViews over PubSub |
+| `PR.Ticker` | GenServer | Every 5s, recomputes and broadcasts playback progress % |
+| `PR.Scheduler` | Quantum (cron) | `@daily` clears the playlist; a morning job runs the group check |
+| `PR.Worker.GetInitialState` | Task | On startup (prod), fetches initial state and subscribes to Sonos webhooks |
+| `PR.Worker.GroupCheck` | GenServer | Verifies the active Sonos group, recreates it if gone |
+
+All UI updates flow over `Phoenix.PubSub` (topics `PR.PlayState` and `PR.Music`).
+The LiveView (`lib/pr_web/live/playback_live/playback_live.ex`) subscribes and
+re-renders on `:play_state`, `:metadata`, `:progress`, and `:queue_updated`.
+
+---
+
+## API reference summary
+
+**Spotify** (`lib/pr/apis/spotify_api.ex`, base `https://api.spotify.com`)
+
+| Function | Call |
+|---|---|
+| `search/1` | `GET /v1/search/?q=&type=track&market=GB&limit=10` |
+| `get_track/1` | `GET /v1/tracks/{id}` |
+| `create_playlist/0` | `POST /v1/users/{spotify_id}/playlists` |
+| `replace_playlist/1` | `PUT /v1/playlists/{playlist_id}/tracks` (body `{uris: [...]}`) |
+| `get_current_user/0` | `GET /v1/me` |
+
+**Sonos** (`lib/pr/apis/sonos_api.ex`, base `https://api.ws.sonos.com/control/api/v1`)
+
+| Function | Call |
+|---|---|
+| `get_households/0` | `GET /households` |
+| `get_groups/0` | `GET /households/{household_id}/groups` |
+| `get_favorites/0` | `GET /households/{household_id}/favorites` |
+| `set_favorite/2` | `POST /groups/{group_id}/favorites` (body `{favoriteId, playOnCompletion: true}`) |
+| `subscribe_webhooks/0` | `POST /groups/{group_id}/playback/subscription` + `.../playbackMetadata/subscription` |
+| `toggle_playback/0` | `POST /groups/{group_id}/playback/togglePlayPause` |
+| `skip/0` | `POST /groups/{group_id}/playback/skipToNextTrack` |
+| `set_volume/1` | `POST /groups/{group_id}/groupVolume` (body `{volume}`) |
+| `create_group/1` | `POST /households/{household_id}/groups/createGroup` |
+
+**Inbound webhook**
+
+| Route | Handler |
+|---|---|
+| `POST /sonos/callback` | `SonosWebhookController.callback` -> `PR.PlayState` |

--- a/docs/soundcloud-plan.md
+++ b/docs/soundcloud-plan.md
@@ -1,0 +1,296 @@
+# Plan: Mixed-provider queue (Spotify + SoundCloud)
+
+Status: proposal. Not started.
+
+Goal: let users queue both Spotify and SoundCloud tracks into the same live
+session, played out of the same Sonos speakers. The DB queue stays the single
+source of truth and remains globally ordered; the provider of each track is just
+an attribute of the row.
+
+This builds on the existing architecture described in `how-it-works.md`. Read that
+first. The short version: PlayRequest does not stream audio. It mirrors the
+unplayed queue into a streaming-service playlist, saves that playlist as a Sonos
+"favourite", tells Sonos to play the favourite, and learns what is playing from
+Sonos webhooks.
+
+---
+
+## 0. Open question / TODO (gating, not yet decided)
+
+**SoundCloud API access requires a paid account.** Whether this feature is worth
+building at all depends on:
+
+- Can we register a SoundCloud app and obtain client credentials at all
+  (registration has historically been closed/intermittent).
+- Does the paid tier expose **playlist track replacement** (the equivalent of
+  Spotify's `PUT /playlists/{id}/tracks`). Without it, the whole mirroring trick
+  has nothing to write to and the feature is dead.
+- Cost vs. value of the paid account.
+
+This needs separate research and a go/no-go before any of the technical work
+below is worth starting. Everything else in this document assumes the answer is
+"yes, and it supports playlist editing".
+
+**Second unknown (cheap to verify, do early):** the shape of a SoundCloud track in
+the Sonos metadata webhook. We rely on `currentItem.track.id.object_id` to match
+the playing track back to a queue row. For Spotify it is `spotify:track:{id}`
+(`lib/pr/music/sonos_item.ex:9`). We need to capture what Sonos sends for a
+SoundCloud track and confirm it carries a stable id we can store and match. This
+can be checked by hand (save a SoundCloud playlist as a favourite, play it, log
+the inbound webhook) before committing to the build.
+
+---
+
+## 1. Design: favourite swapping at provider boundaries
+
+A Sonos favourite points at one service's playlist, and Sonos plays that one
+playlist autonomously. There is no Sonos API to "play this arbitrary list of
+mixed-service track ids". So we keep two favourites - one Spotify playlist, one
+SoundCloud playlist - and play the queue as a sequence of single-provider
+**runs**.
+
+A run is a maximal contiguous block of same-provider tracks in queue order. For
+the queue `S1 S2 C1 S3 C2 C3 S4` the runs are:
+
+```
+[S1 S2]  [C1]  [S3]  [C2 C3]  [S4]
+```
+
+At any moment we load only the **current run** into its provider's playlist and
+trigger that provider's favourite. Sonos plays the run gaplessly, then reaches the
+end of the (short) playlist and goes idle. Idle-with-tracks-remaining is the
+existing re-trigger signal (`PR.PlayState.watch_play_state/1`,
+`lib/pr/play_state.ex:153`); we reuse it to load and trigger the next run.
+
+Important: we deliberately load only the current run, not all of a provider's
+unplayed tracks. If the Spotify playlist held `[S1 S2 S3 S4]`, Sonos would play
+straight through and never stop for `C1`. Loading just `[S1 S2]` makes Sonos go
+idle exactly at the boundary, which is where we take back control.
+
+### What this reuses (already in the codebase)
+
+- **Boundary "mark played".** When the next run's first track starts, its metadata
+  event marks any *other* still-playing track as played
+  (`Queue.set_current_transaction/2`, `lib/pr/queue/queue.ex:255`, via
+  `where external_id != ^id`). So the last track of the previous run is marked
+  played when the next run starts; no special boundary handling needed. At the
+  true end of the queue, the empty-metadata path (`Queue.set_current(%{})`) marks
+  it played as it does today.
+- **Skip across a boundary.** `Music.skip/1` already handles "nothing left in the
+  Sonos queue" by bumping the current track and re-triggering, with rollback on
+  failure (`lib/pr/music/music.ex:149`). Skipping the last track of a run lands in
+  that path unchanged.
+- **Idle re-trigger.** The boundary trigger is the existing idle handler, just
+  firing more often.
+
+### What this costs
+
+- **A gap at every provider switch.** `set_favorite` reloads the Sonos group queue
+  and restarts playback, plus the ~1s idle-retrigger delay
+  (`lib/pr/play_state.ex:165`). Within a run, playback is gapless. Worst case is
+  track-by-track alternation; clustered queues switch rarely.
+- **More re-triggers, more race surface.** `trigger_playlist/1` is already flagged
+  as slow and race-prone if called repeatedly before play state settles
+  (`lib/pr/music/music.ex:77`). Each switch is several HTTP round-trips. Switching
+  per run multiplies the desync window between DB and Sonos state. This is the
+  main place runtime bugs will show up and where test/observability effort should
+  go.
+
+---
+
+## 2. Data model
+
+`tracks.spotify_id` becomes provider-qualified. Add a provider column; keep the id
+column but rename its meaning to a generic external id.
+
+```
+provider     :string   # "spotify" | "soundcloud"
+external_id  :string   # was spotify_id; provider-scoped track id
+```
+
+Migration work:
+
+- Add `provider` (default `"spotify"` to backfill existing rows), rename
+  `spotify_id` -> `external_id`.
+- Unique constraint `already_queued` becomes a composite on
+  `(provider, external_id)` instead of `spotify_id` alone
+  (`lib/pr/queue/track.ex:49`).
+- The novelty views join on `spotify_id`
+  (`track_novelty`, `artist_novelty`; used in `lib/pr/queue/queue.ex:380` and the
+  raw SQL in `get_novelty_for_search_results/1`, `queue.ex:113`). Decide whether
+  novelty is per-provider or cross-provider. Simplest: keep novelty keyed on the
+  external id and accept that the same song on two services counts separately.
+  Update the views and the raw query to the renamed column either way.
+- `SonosItem` (`lib/pr/music/sonos_item.ex`) and `SearchTrack`
+  (`lib/pr/music/search_track.ex`) gain a `provider` field.
+
+Matching in `set_current_transaction/2` currently compares `external_id` only.
+Cross-provider ids will not collide in practice, but qualify the match by
+`provider` as well to be safe.
+
+---
+
+## 3. Provider abstraction
+
+Introduce a behaviour so `Music` is provider-agnostic and the Spotify-specific
+code moves behind it. SoundCloud gets a parallel implementation.
+
+```elixir
+defmodule PR.Music.Provider do
+  @callback search(query :: String.t()) :: {:ok, [SearchTrack.t()]} | {:error, term()}
+  @callback get_track(id :: String.t()) :: {:ok, SearchTrack.t()} | {:error, term()}
+  @callback replace_playlist(ids :: [String.t()]) :: {:ok, term()} | {:error, term()}
+  @callback favourite_name() :: String.t()        # name of the Sonos favourite to match
+  @callback object_id(external_id :: String.t()) :: String.t()  # e.g. "spotify:track:" <> id
+  @callback match_object_id(object_id :: String.t()) :: {:ok, external_id :: String.t()} | :no_match
+end
+```
+
+- `PR.Music.Provider.Spotify` wraps the current `PR.SpotifyAPI` calls
+  (`search/1`, `get_track/1`, `replace_playlist/1`) and the `spotify:track:` URI
+  shape.
+- `PR.Music.Provider.SoundCloud` is the new module: a new OAuth client + HTTP
+  layer (reuse `PR.Apis.TokenHelper` / `PR.Apis.EndpointHelper`), search, get
+  track, and playlist replace against SoundCloud's API, plus its own object-id
+  shape (to be confirmed - see section 0).
+
+`provider_for/1` maps a provider atom/string to its module.
+
+---
+
+## 4. Search and queueing (per provider)
+
+- Search needs to target a provider. Either a provider toggle in the search UI, or
+  search both and tag results by provider. Simplest first cut: a toggle, default
+  Spotify. `Music.search/1` -> `provider.search/1`.
+- `Music.queue/2` already takes an id; extend it to take a provider too, fetch
+  metadata via `provider.get_track/1`, and store `provider` + `external_id` on the
+  row (`lib/pr/music/music.ex:39`).
+- The idle-vs-playing branch in `queue/2` is unchanged in shape, but
+  `sync_playlist` becomes run-aware (next section).
+
+---
+
+## 5. Run slicing and playlist sync
+
+This is the core new logic. Replace the single "load all unplayed" sync with
+"load the current run".
+
+- `Queue.list_track_uris/0` currently returns all unplayed ids
+  (`lib/pr/queue/queue.ex:71`). Add `Queue.current_run/0` returning the contiguous
+  same-provider block at the head of the unplayed queue (ordered by `inserted_at`)
+  as `{provider, [external_id]}`.
+- `Music.sync_playlist/0` becomes: take the current run, call
+  `provider.replace_playlist(ids)` for that provider, and remember which provider
+  is "active" so triggering knows which favourite to use
+  (`lib/pr/music/music.ex:61`).
+- `find_playlist/1` matches the Sonos favourite by name
+  (`lib/pr/music/music.ex:197`). Match against `provider.favourite_name/0` for the
+  active run's provider. This means two favourites must exist in the Sonos app, one
+  per provider, named to match.
+
+Edge case - appending while a run plays: queueing another track of the
+**currently active** provider can extend the current run's playlist (same as today
+within a run). Queueing a different-provider track, or a same-provider track that
+is not contiguous with the current run, just sits in the DB queue and gets loaded
+when its run is reached. No live mutation needed for those.
+
+---
+
+## 6. Triggering and the boundary loop
+
+`trigger_playlist/1` (`lib/pr/music/music.ex:79`) stays structurally the same:
+
+1. `sync_playlist` (now loads the current run).
+2. `check_unplayed`.
+3. get active group.
+4. `get_favorites` -> `find_playlist` (now provider-specific name).
+5. `check_current_playstate`.
+6. `set_favorite`.
+
+The boundary loop: run plays -> Sonos idle -> `watch_play_state(:idle)` sees
+unplayed tracks remain -> `trigger_on_sonos_system` -> `trigger_playlist` ->
+loads the next run (which may be the other provider) -> plays. Repeat until the
+queue is empty, at which point idle with no unplayed tracks stops the loop
+(`lib/pr/play_state.ex:160`).
+
+---
+
+## 7. Metadata feedback (both providers)
+
+- `SonosItem.new/1` hard-matches `spotify:track:` (`lib/pr/music/sonos_item.ex:9`).
+  Generalise: detect provider from the object-id shape, populate `provider` +
+  `external_id`. Delegate the shape match to the provider modules
+  (`match_object_id/1`).
+- `cast_metadata/1` (`lib/pr/play_state.ex:294`) drops non-Spotify items to
+  "playing something else". Once SoundCloud shapes are recognised, they flow
+  through `update_playing/1` -> `Queue.set_current/1` like Spotify items.
+- `Queue.set_current/1` matching is by external id (qualified by provider per
+  section 2).
+
+If the SoundCloud object-id does not carry a stable, matchable id, this is a hard
+blocker for SoundCloud playback feedback - resolve in the section 0 spike before
+building.
+
+---
+
+## 8. Auth
+
+SoundCloud is a second OAuth2 authorization-code service, same pattern as Spotify
+and Sonos (`how-it-works.md` section 6). Reuse `PR.Apis.TokenHelper` and the
+`tokens` table keyed by `service` (`Elixir.PR.Music.Provider.SoundCloud`). Add:
+
+- A `client/0` with SoundCloud authorize/token URLs and scopes.
+- A redirect route and handling in `PRWeb.Service.ServiceAuthController` (mirror
+  the Spotify case).
+- A SoundCloud section on the setup screen to authorise and to create/verify the
+  SoundCloud playlist (mirror `create_playlist`).
+
+---
+
+## 9. Setup / operational
+
+- Two Sonos favourites must exist, one per provider, named to match each
+  provider's `favourite_name/0`. Document this in setup; `find_playlist` already
+  errors clearly if a favourite is missing.
+- The `@daily` playlist clear (`PR.Scheduler`) must clear both playlists.
+- Per-provider playlist creation on the setup screen.
+
+---
+
+## 10. Risks (ordered)
+
+1. **SoundCloud API access + playlist editing (paid, unverified).** Section 0.
+   Go/no-go gate.
+2. **SoundCloud Sonos metadata id shape (unverified).** Section 0 spike. If
+   unmatchable, feedback loop breaks.
+3. **Switch-boundary races.** More frequent triggering widens the existing
+   DB-vs-Sonos desync window (`music.ex:77`). Needs careful logging and probably
+   integration testing around boundaries.
+4. **Gap on provider switch.** Inherent to favourite reloading. Product-acceptable
+   or not is a call to make.
+5. **Live append assumption.** Mutating a playlist Sonos is mid-playing is a
+   pre-existing assumption; in this design it is scoped to within the active run.
+
+---
+
+## 11. Suggested order of work
+
+1. (Gate) Research SoundCloud paid API access + playlist edit support. Go/no-go.
+2. (Spike) Save a SoundCloud playlist as a Sonos favourite, play it, capture the
+   metadata webhook. Confirm a matchable id. Go/no-go.
+3. Data model: `provider` + `external_id` migration, constraint, novelty views,
+   structs.
+4. Provider behaviour + extract `Provider.Spotify` from current code. No behaviour
+   change yet (Spotify-only, still works end to end).
+5. Run slicing: `Queue.current_run/0`, run-aware `sync_playlist`, provider-aware
+   `find_playlist`. Still Spotify-only - verify the boundary loop works with an
+   all-Spotify queue split into artificial runs.
+6. `Provider.SoundCloud`: auth, search, get track, replace playlist, object-id.
+7. Metadata: generalise `SonosItem` / `cast_metadata`.
+8. UI: provider toggle in search; setup screen for SoundCloud auth + playlist.
+9. Integration testing focused on boundary transitions and skips across providers.
+
+Steps 4 and 5 are valuable on their own: they make the system provider-agnostic
+and exercise the run-boundary loop using only Spotify, so the riskiest mechanics
+are proven before SoundCloud is added.

--- a/lib/pr/music/music.ex
+++ b/lib/pr/music/music.ex
@@ -2,9 +2,8 @@ defmodule PR.Music do
   require Logger
 
   alias PR.SonosAPI
-  alias PR.SpotifyAPI
   alias PR.PlayState
-  alias PR.Music.{SearchTrack, PlaybackState}
+  alias PR.Music.{SearchTrack, PlaybackState, Provider}
   alias PR.Queue
   alias PR.Queue.Track
   alias PR.SonosHouseholds
@@ -21,26 +20,21 @@ defmodule PR.Music do
   end
 
   @spec search(String.t()) :: {:ok, [SearchTrack.t()]} | {:error}
-  def search(q) do
-    case SpotifyAPI.search(q) do
+  def search(q, provider \\ Provider.default()) do
+    case Provider.for(provider).search(q) do
       {:ok, tracks} ->
-        tracks =
-          tracks
-          |> Enum.map(&SearchTrack.new/1)
-          |> Queue.get_novelty_for_search_results()
-
-        {:ok, tracks}
+        {:ok, Queue.get_novelty_for_search_results(tracks)}
 
       err ->
         err
     end
   end
 
-  @spec queue(User.t(), String.t()) :: {:ok, Track.t()}
-  def queue(%User{id: user_id}, id) do
-    Logger.info("Queuing: spotify:track:#{id}")
+  @spec queue(User.t(), String.t(), String.t()) :: {:ok, Track.t()}
+  def queue(%User{id: user_id}, external_id, provider \\ Provider.default()) do
+    Logger.info("Queuing: #{provider}:#{external_id}")
 
-    with {:ok, search_track} <- get_track(id),
+    with {:ok, search_track} <- Provider.for(provider).get_track(external_id),
          search_track <- Map.put(search_track, :user_id, user_id),
          {:ok, queued_track} <- create_track(search_track) do
       queue_updated()
@@ -59,11 +53,11 @@ defmodule PR.Music do
   end
 
   def sync_playlist do
-    Logger.info("Syncing tracks to Spotify playlist")
+    Logger.info("Syncing tracks to provider playlist")
 
     Queue.list_track_uris()
-    |> Enum.map(fn {id} -> "spotify:track:" <> id end)
-    |> SpotifyAPI.replace_playlist()
+    |> Enum.map(fn {id} -> id end)
+    |> default_provider().replace_playlist()
 
     {:ok}
   end
@@ -97,7 +91,7 @@ defmodule PR.Music do
 
       {:error, :playlist_not_created} ->
         Logger.error("Trigger playlist: Playlist not created")
-        {:error, "Couldn't find #{get_playlist_name()} in Sonos favorites"}
+        {:error, "Couldn't find #{default_provider().favourite_name()} in Sonos favorites"}
 
       {:error, :gone} ->
         Logger.error("Trigger playlist: Fav gone, try re-saving groups")
@@ -105,7 +99,7 @@ defmodule PR.Music do
 
       _ ->
         Logger.error("Trigger playlist: Unknown error")
-        {:error, "Could not load playlist #{get_playlist_name()}"}
+        {:error, "Could not load playlist #{default_provider().favourite_name()}"}
     end
   end
 
@@ -196,7 +190,7 @@ defmodule PR.Music do
 
   @spec find_playlist([map()]) :: {:ok, String.t()} | {:error, atom()}
   defp find_playlist(sonos_favorites) do
-    case Enum.find(sonos_favorites, &(&1.name == get_playlist_name())) do
+    case Enum.find(sonos_favorites, &(&1.name == default_provider().favourite_name())) do
       %{id: id} ->
         {:ok, id}
 
@@ -212,17 +206,5 @@ defmodule PR.Music do
     |> Queue.create_track()
   end
 
-  @spec get_track(String.t()) :: {:ok, SearchTrack.t()} | {:error}
-  defp get_track(id) do
-    with track_data <- SpotifyAPI.get_track(id),
-         %SearchTrack{} = track <- SearchTrack.new(track_data) do
-      {:ok, track}
-    else
-      err -> err
-    end
-  end
-
-  defp get_playlist_name do
-    Application.get_env(:pr, :playlist_name)
-  end
+  defp default_provider, do: Provider.for(Provider.default())
 end

--- a/lib/pr/music/provider.ex
+++ b/lib/pr/music/provider.ex
@@ -1,0 +1,37 @@
+defmodule PR.Music.Provider do
+  @moduledoc """
+  Behaviour for a streaming-service provider. The queue and playback pipeline
+  talk to this rather than to a specific service, so a new service is added by
+  implementing the callbacks and registering the module in `@providers`.
+  """
+
+  alias PR.Music.SearchTrack
+
+  @callback search(query :: String.t()) :: {:ok, [SearchTrack.t()]} | {:error, term()}
+  @callback get_track(external_id :: String.t()) :: {:ok, SearchTrack.t()} | {:error, term()}
+  @callback replace_playlist(external_ids :: [String.t()]) :: {:ok, term()} | {:error, term()}
+  @callback favourite_name() :: String.t()
+
+  # The Sonos metadata object_id for a track, e.g. "spotify:track:" <> id
+  @callback parse_object_id(object_id :: String.t()) ::
+              {:ok, external_id :: String.t()} | :no_match
+
+  @providers %{"spotify" => PR.Music.Provider.Spotify}
+
+  @spec for(String.t()) :: module()
+  def for(provider), do: Map.fetch!(@providers, provider)
+
+  @spec default() :: String.t()
+  def default, do: Application.get_env(:pr, :default_provider)
+
+  @doc "Find the provider that recognises a Sonos object_id."
+  @spec match_object_id(String.t()) :: {:ok, provider :: String.t(), external_id :: String.t()} | :no_match
+  def match_object_id(object_id) do
+    Enum.find_value(@providers, :no_match, fn {provider, mod} ->
+      case mod.parse_object_id(object_id) do
+        {:ok, external_id} -> {:ok, provider, external_id}
+        :no_match -> nil
+      end
+    end)
+  end
+end

--- a/lib/pr/music/provider/spotify.ex
+++ b/lib/pr/music/provider/spotify.ex
@@ -1,0 +1,38 @@
+defmodule PR.Music.Provider.Spotify do
+  @behaviour PR.Music.Provider
+
+  alias PR.SpotifyAPI
+  alias PR.Music.SearchTrack
+
+  @provider "spotify"
+
+  @impl true
+  def search(query) do
+    case SpotifyAPI.search(query) do
+      {:ok, tracks} -> {:ok, Enum.map(tracks, &SearchTrack.new(&1, @provider))}
+      err -> err
+    end
+  end
+
+  @impl true
+  def get_track(external_id) do
+    case SpotifyAPI.get_track(external_id) do
+      %{} = track_data -> {:ok, SearchTrack.new(track_data, @provider)}
+      err -> err
+    end
+  end
+
+  @impl true
+  def replace_playlist(external_ids) do
+    external_ids
+    |> Enum.map(&("spotify:track:" <> &1))
+    |> SpotifyAPI.replace_playlist()
+  end
+
+  @impl true
+  def favourite_name, do: Application.get_env(:pr, :playlist_name)
+
+  @impl true
+  def parse_object_id("spotify:track:" <> external_id), do: {:ok, external_id}
+  def parse_object_id(_), do: :no_match
+end

--- a/lib/pr/music/search_track.ex
+++ b/lib/pr/music/search_track.ex
@@ -1,20 +1,22 @@
 defmodule PR.Music.SearchTrack do
-  defstruct [:name, :artist, :duration, :img, :spotify_id, :track_novelty, :artist_novelty]
+  defstruct [:name, :artist, :duration, :img, :provider, :external_id, :track_novelty, :artist_novelty]
 
-  @spec new(map()) :: SearchTrack.t()
+  @spec new(map(), String.t()) :: SearchTrack.t()
   def new(
         %{
           id: id,
           name: name,
           duration_ms: duration,
           artists: [%{name: artist} | _]
-        } = params
+        } = params,
+        provider
       ) do
     %__MODULE__{
       name: name,
       artist: artist,
       duration: trunc(duration),
-      spotify_id: id
+      provider: provider,
+      external_id: id
     }
     |> Map.merge(get_image(params))
   end

--- a/lib/pr/music/sonos_item.ex
+++ b/lib/pr/music/sonos_item.ex
@@ -1,23 +1,26 @@
 defmodule PR.Music.SonosItem do
-  defstruct [:name, :artist, :duration, :spotify_id, :spotify_uri, playing_since: nil]
+  alias PR.Music.Provider
+
+  defstruct [:name, :artist, :duration, :provider, :external_id, :object_id, playing_since: nil]
 
   @spec new(map()) :: SonosItem.t()
-  def new(
-        %{
-          track: %{
-            id: %{object_id: "spotify:track:" <> spotify_id},
-            name: name,
-            artist: %{name: artist},
-            duration_millis: duration
-          }
+  def new(%{
+        track: %{
+          id: %{object_id: object_id},
+          name: name,
+          artist: %{name: artist},
+          duration_millis: duration
         }
-      ) do
+      }) do
+    {:ok, provider, external_id} = Provider.match_object_id(object_id)
+
     %__MODULE__{
       name: name,
       artist: artist,
       duration: duration,
-      spotify_uri: "spotify:track:" <> spotify_id,
-      spotify_id: spotify_id
+      provider: provider,
+      external_id: external_id,
+      object_id: object_id
     }
   end
 end

--- a/lib/pr/queue/queue.ex
+++ b/lib/pr/queue/queue.ex
@@ -74,7 +74,7 @@ defmodule PR.Queue do
     |> query_unplayed()
     |> order()
     |> limit(100)
-    |> select([t], {t.spotify_id})
+    |> select([t], {t.external_id})
     |> Repo.all()
   end
 
@@ -114,7 +114,7 @@ defmodule PR.Queue do
   def get_novelty_for_search_results(tracks) do
     search_results =
       tracks
-      |> Enum.map(fn %{spotify_id: spotify_id, artist: artist} -> [spotify_id, artist] end)
+      |> Enum.map(fn %{external_id: external_id, artist: artist} -> [external_id, artist] end)
       |> Enum.map(fn values -> values |> Enum.map(&escape_quotes/1) end)
       |> Enum.map(fn values -> values |> Enum.map(&"'#{&1}'") end)
       |> Enum.map(fn values ->
@@ -124,7 +124,7 @@ defmodule PR.Queue do
 
     query = """
     WITH
-      search_results(spotify_id, artist) AS (
+      search_results(external_id, artist) AS (
         VALUES #{search_results}
       )
     select
@@ -132,7 +132,7 @@ defmodule PR.Queue do
       coalesce(artist_novelty, 100) as artist_novelty
     from
       search_results
-      left join track_novelty on search_results.spotify_id = track_novelty.spotify_id
+      left join track_novelty on search_results.external_id = track_novelty.external_id
       left join artist_novelty on search_results.artist = artist_novelty.artist
     """
 
@@ -192,11 +192,11 @@ defmodule PR.Queue do
   end
 
   @spec set_current(SonosItem.t()) :: {:started | :already_started, DateTime.t()} | {:ok}
-  def set_current(%SonosItem{spotify_id: spotify_id, name: name}) do
+  def set_current(%SonosItem{provider: provider, external_id: external_id, name: name}) do
     Logger.info("Set current: #{name}")
     now = DateTime.utc_now()
 
-    set_current_transaction(spotify_id, now)
+    set_current_transaction(provider, external_id, now)
   end
 
   def set_current(_) do
@@ -247,15 +247,15 @@ defmodule PR.Queue do
     end
   end
 
-  @spec set_current_transaction(String.t(), DateTime.t()) ::
+  @spec set_current_transaction(String.t(), String.t(), DateTime.t()) ::
           {:ok, [played: integer, playing: integer]}
-  defp set_current_transaction(spotify_id, now) do
+  defp set_current_transaction(provider, external_id, now) do
     Repo.transaction(fn ->
       # Anything else that was playing now isn't, cos this new track is
       played =
         Track
         |> query_is_playing()
-        |> where([t], t.spotify_id != ^spotify_id)
+        |> where([t], t.external_id != ^external_id or t.provider != ^provider)
         |> Repo.update_all(set: [playing_since: nil, played_at: now])
         |> case do
           {0, nil} ->
@@ -271,7 +271,8 @@ defmodule PR.Queue do
       # If its not already played or already marked as playing
       playing =
         Track
-        |> where([t], t.spotify_id == ^spotify_id)
+        |> where([t], t.provider == ^provider)
+        |> where([t], t.external_id == ^external_id)
         |> where([t], is_nil(t.played_at))
         |> where([t], is_nil(t.playing_since))
         |> Repo.update_all(set: [playing_since: now])
@@ -384,7 +385,7 @@ defmodule PR.Queue do
       :left,
       [t],
       tn in TrackNovelty,
-      on: tn.spotify_id == t.spotify_id,
+      on: tn.external_id == t.external_id,
       as: :track_novelty
     )
     |> join(

--- a/lib/pr/queue/track.ex
+++ b/lib/pr/queue/track.ex
@@ -9,7 +9,8 @@ defmodule PR.Queue.Track do
     field(:artist, :string)
     field(:duration, :integer)
     field(:img, :string)
-    field(:spotify_id, :string)
+    field(:provider, :string)
+    field(:external_id, :string)
     field(:name, :string)
     field(:played_at, :utc_datetime)
     field(:playing_since, :utc_datetime)
@@ -38,14 +39,15 @@ defmodule PR.Queue.Track do
       :name,
       :artist,
       :img,
-      :spotify_id,
+      :provider,
+      :external_id,
       :duration,
       :played_at,
       :playing_since,
       :user_id
     ])
-    |> validate_required([:name, :artist, :img, :spotify_id, :duration, :user_id])
+    |> validate_required([:name, :artist, :img, :provider, :external_id, :duration, :user_id])
     |> validate_exclusion(:name, ["World in Motion"])
-    |> unique_constraint(:spotify_id, name: :already_queued, message: "Already queued")
+    |> unique_constraint(:external_id, name: :already_queued, message: "Already queued")
   end
 end

--- a/lib/pr/queue/track_novelty.ex
+++ b/lib/pr/queue/track_novelty.ex
@@ -2,7 +2,7 @@ defmodule PR.Queue.TrackNovelty do
   use Ecto.Schema
 
   schema "track_novelty" do
-    field(:spotify_id, :string)
+    field(:external_id, :string)
     field(:track_novelty, :integer)
   end
 end

--- a/lib/pr_web/controllers/history_html/index.html.heex
+++ b/lib/pr_web/controllers/history_html/index.html.heex
@@ -15,7 +15,7 @@
 
             <div class="track__details">
               <h3 class="track__name">
-                <.link href={{:"spotify:track", track.spotify_id}} title="Open in Spotify">
+                <.link href={{:"spotify:track", track.external_id}} title="Open in Spotify">
                   <img src={~p"/images/spotify.svg"} class="spotify" />
                   <span class="link"><%= track.name %></span>
                 </.link>

--- a/lib/pr_web/live/playback_live/playback_live.ex
+++ b/lib/pr_web/live/playback_live/playback_live.ex
@@ -183,8 +183,8 @@ defmodule PRWeb.PlaybackLive do
     {:noreply, assign(socket, playlist: items)}
   end
 
-  def handle_info({:queue, spotify_id}, %{assigns: %{current_user: user}} = socket) do
-    case Music.queue(user, spotify_id) do
+  def handle_info({:queue, external_id}, %{assigns: %{current_user: user}} = socket) do
+    case Music.queue(user, external_id) do
       {:ok, _track} ->
         socket =
           socket
@@ -193,10 +193,10 @@ defmodule PRWeb.PlaybackLive do
 
         {:noreply, socket}
 
-      #  Only pass error message for spotify_id field, as there are some other changeset
+      #  Only pass error message for external_id field, as there are some other changeset
       # errors that we don't want to tell people about
-      {:error, %{errors: [{:spotify_id, {message, _}} | _tail]}} ->
-        Logger.warn("Double unplayed queue prevented: #{spotify_id}")
+      {:error, %{errors: [{:external_id, {message, _}} | _tail]}} ->
+        Logger.warn("Double unplayed queue prevented: #{external_id}")
 
         socket =
           socket
@@ -248,8 +248,8 @@ defmodule PRWeb.PlaybackLive do
   ## User events
 
   @impl true
-  def handle_event("queue", %{"value" => spotify_id}, socket) do
-    send(self(), {:queue, spotify_id})
+  def handle_event("queue", %{"value" => external_id}, socket) do
+    send(self(), {:queue, external_id})
     {:noreply, assign(socket, participated: true)}
   end
 

--- a/lib/pr_web/live/playback_live/playback_live.html.heex
+++ b/lib/pr_web/live/playback_live/playback_live.html.heex
@@ -23,7 +23,7 @@
             <%= if is_playing?(track, @play_state) do %>
               <img src={~p"/images/playing-icon.svg"} class="track__playing" />
             <% end %>
-            <.link href={{:"spotify:track", track.spotify_id}} title="Open in Spotify">
+            <.link href={{:"spotify:track", track.external_id}} title="Open in Spotify">
               <span class="link"><%= track.name %></span>
             </.link>
             <%= if track.track_novelty < 20 do %>

--- a/lib/pr_web/live/playback_live/search_results.html.heex
+++ b/lib/pr_web/live/playback_live/search_results.html.heex
@@ -30,7 +30,7 @@
           title="Add to queue"
           class="track__queue"
           phx-click="queue"
-          value={track.spotify_id}
+          value={track.external_id}
           style={
              "transform: scale(#{max(get_track_novelty(track) / 100, 0.2)})"
           }
@@ -41,7 +41,7 @@
           title="Add to queue"
           class="track__queue"
           phx-click="queue"
-          value={track.spotify_id}
+          value={track.external_id}
         >
         </button>
       </div>

--- a/priv/repo/migrations/20260622120000_add_provider_to_tracks.exs
+++ b/priv/repo/migrations/20260622120000_add_provider_to_tracks.exs
@@ -1,0 +1,185 @@
+defmodule PR.Repo.Migrations.AddProviderToTracks do
+  use Ecto.Migration
+
+  # Renames tracks.spotify_id -> external_id and adds a provider column so the
+  # queue can hold tracks from more than one streaming service. The novelty
+  # views select the renamed column, so they are dropped and recreated.
+
+  def up do
+    execute "DROP VIEW track_novelty"
+    execute "DROP VIEW artist_novelty"
+    execute "DROP VIEW recent_plays"
+
+    drop unique_index(:tracks, [:spotify_id], name: :already_queued)
+
+    rename table(:tracks), :spotify_id, to: :external_id
+
+    alter table(:tracks) do
+      add :provider, :string, null: false, default: "spotify"
+    end
+
+    create unique_index(:tracks, [:provider, :external_id],
+             where: "played_at is null",
+             name: :already_queued
+           )
+
+    recreate_views()
+  end
+
+  def down do
+    execute "DROP VIEW track_novelty"
+    execute "DROP VIEW artist_novelty"
+    execute "DROP VIEW recent_plays"
+
+    drop unique_index(:tracks, [:provider, :external_id], name: :already_queued)
+
+    alter table(:tracks) do
+      remove :provider
+    end
+
+    rename table(:tracks), :external_id, to: :spotify_id
+
+    create unique_index(:tracks, [:spotify_id], where: "played_at is null", name: :already_queued)
+
+    recreate_legacy_views()
+  end
+
+  defp recreate_views do
+    execute """
+      CREATE VIEW recent_plays as (
+        select
+          t.external_id,
+          t.provider,
+          t.name,
+          t.artist,
+          floor(
+            (
+              extract(
+                epoch
+                from
+                  t.inserted_at - (now() - interval '3 week')
+              )
+            ) / 36000
+          ) as recency
+        from
+          tracks t
+        where
+          t.inserted_at > now() - interval '3 week'
+          and t.played_at is not null
+        order by
+          recency desc
+      )
+    """
+
+    execute """
+      CREATE VIEW artist_novelty as (
+        with artist_un_novelty as (
+          select
+            count(1) * max(recency) as un_novelty,
+            artist
+          from
+            recent_plays
+          group by
+            artist
+        )
+        select
+          artist,
+          floor(100 - (un_novelty / (
+            select max(un_novelty) from artist_un_novelty
+          ) * 100))::integer as artist_novelty
+        from
+          artist_un_novelty
+      )
+    """
+
+    execute """
+      CREATE VIEW track_novelty as (
+        with track_un_novelty as (
+          select
+            count(1) * max(recency) as un_novelty,
+            external_id
+          from
+            recent_plays
+          group by
+            external_id
+        )
+        select
+          external_id,
+          floor(100 - (un_novelty / (
+            select max(un_novelty) from track_un_novelty
+          ) * 100))::integer as track_novelty
+        from
+          track_un_novelty
+      )
+    """
+  end
+
+  defp recreate_legacy_views do
+    execute """
+      CREATE VIEW recent_plays as (
+        select
+          t.spotify_id,
+          t.name,
+          t.artist,
+          floor(
+            (
+              extract(
+                epoch
+                from
+                  t.inserted_at - (now() - interval '3 week')
+              )
+            ) / 36000
+          ) as recency
+        from
+          tracks t
+        where
+          t.inserted_at > now() - interval '3 week'
+          and t.played_at is not null
+        order by
+          recency desc
+      )
+    """
+
+    execute """
+      CREATE VIEW artist_novelty as (
+        with artist_un_novelty as (
+          select
+            count(1) * max(recency) as un_novelty,
+            artist
+          from
+            recent_plays
+          group by
+            artist
+        )
+        select
+          artist,
+          floor(100 - (un_novelty / (
+            select max(un_novelty) from artist_un_novelty
+          ) * 100))::integer as artist_novelty
+        from
+          artist_un_novelty
+      )
+    """
+
+    execute """
+      CREATE VIEW track_novelty as (
+        with track_un_novelty as (
+          select
+            count(1) * max(recency) as un_novelty,
+            spotify_id
+          from
+            recent_plays
+          group by
+            spotify_id
+        )
+        select
+          spotify_id,
+          floor(100 - (un_novelty / (
+            select max(un_novelty) from track_un_novelty
+          ) * 100))::integer as track_novelty
+        from
+          track_un_novelty
+      )
+    """
+  end
+end

--- a/priv/repo/migrations/20260623090000_longer_user_token.exs
+++ b/priv/repo/migrations/20260623090000_longer_user_token.exs
@@ -1,0 +1,15 @@
+defmodule PR.Repo.Migrations.LongerUserToken do
+  use Ecto.Migration
+
+  def up do
+    alter table(:users) do
+      modify :token, :text
+    end
+  end
+
+  def down do
+    alter table(:users) do
+      modify :token, :string, size: 255
+    end
+  end
+end

--- a/test/pr/play_state_test.exs
+++ b/test/pr/play_state_test.exs
@@ -20,7 +20,7 @@ defmodule PR.PlayStateTest do
     test "updates playing track from metadata", %{mocked_now: now} do
       spotify_track_id = "123"
       spotify_id = "spotify:track:#{spotify_track_id}"
-      queue_track = insert(:track, spotify_id: spotify_track_id)
+      queue_track = insert(:track, external_id: spotify_track_id)
       metadata = build(:metadata, current_item: build(:metadata_track, id: spotify_id))
 
       # Act
@@ -32,7 +32,7 @@ defmodule PR.PlayStateTest do
       refute is_nil(playing_since)
 
       # Check agent state
-      assert %{current_item: %SonosItem{spotify_id: ^spotify_track_id}} = PlayState.get(:metadata)
+      assert %{current_item: %SonosItem{external_id: ^spotify_track_id}} = PlayState.get(:metadata)
     end
 
     test "updates playing track, marks last track played from metadata", %{mocked_now: now} do
@@ -40,7 +40,7 @@ defmodule PR.PlayStateTest do
       spotify_id = "spotify:track:#{spotify_track_id}"
 
       previous_track = insert(:playing_track)
-      queue_track = insert(:track, spotify_id: spotify_track_id)
+      queue_track = insert(:track, external_id: spotify_track_id)
       metadata = build(:metadata, current_item: build(:metadata_track, id: spotify_id))
 
       # Act
@@ -58,7 +58,7 @@ defmodule PR.PlayStateTest do
       assert played_at == now
 
       # Check agent state
-      assert %{current_item: %SonosItem{spotify_id: ^spotify_track_id}} = PlayState.get(:metadata)
+      assert %{current_item: %SonosItem{external_id: ^spotify_track_id}} = PlayState.get(:metadata)
     end
 
     test "error mode, dont update track when it says playing nothing", %{mocked_now: now} do
@@ -110,7 +110,7 @@ defmodule PR.PlayStateTest do
       spotify_id = "spotify:track:#{spotify_track_id}"
 
       previous_track = insert(:playing_track)
-      queue_track = insert(:track, spotify_id: spotify_track_id)
+      queue_track = insert(:track, external_id: spotify_track_id)
       metadata = build(:metadata, current_item: %{}, next_item: %{})
 
       # Act
@@ -136,7 +136,7 @@ defmodule PR.PlayStateTest do
     #   spotify_id = "spotify:track:#{spotify_track_id}"
 
     #   previous_track = insert(:recently_playing_track)
-    #   queue_track = insert(:track, spotify_id: spotify_track_id)
+    #   queue_track = insert(:track, external_id: spotify_track_id)
     #   metadata = build(:metadata, current_item: %{}, next_item: %{})
 
     #   # Act
@@ -163,7 +163,7 @@ defmodule PR.PlayStateTest do
       spotify_track_id = "123"
       spotify_id = "spotify:track:#{spotify_track_id}"
 
-      queue_track = insert(:track, spotify_id: spotify_track_id)
+      queue_track = insert(:track, external_id: spotify_track_id)
       current_item_from_ages_ago = build(:metadata_track)
       metadata = build(:metadata, current_item: current_item_from_ages_ago, next_item: %{})
 
@@ -183,7 +183,7 @@ defmodule PR.PlayStateTest do
       spotify_track_id = "123"
       spotify_id = "spotify:track:#{spotify_track_id}"
 
-      queue_track = insert(:playing_track, spotify_id: spotify_track_id)
+      queue_track = insert(:playing_track, external_id: spotify_track_id)
       current_item_from_ages_ago = build(:metadata_track)
       metadata = build(:metadata, current_item: current_item_from_ages_ago, next_item: %{})
 

--- a/test/pr/queue_test.exs
+++ b/test/pr/queue_test.exs
@@ -59,30 +59,30 @@ defmodule PR.QueueTest do
   describe "queuing" do
     test "can't queue something twice if its unplayed" do
       me = insert(:user)
-      insert(:track, spotify_id: "derp", played_at: nil, playing_since: nil)
-      params = params_for(:track, spotify_id: "derp", user_id: me.id)
+      insert(:track, external_id: "derp", played_at: nil, playing_since: nil)
+      params = params_for(:track, external_id: "derp", user_id: me.id)
 
       assert {:error, %{errors: errors}} = Queue.create_track(params)
-      assert {:spotify_id, {"Already queued", _}} = errors |> Enum.at(0)
+      assert {:external_id, {"Already queued", _}} = errors |> Enum.at(0)
     end
 
     test "can't queue something twice if its playing and marked unplayed" do
       me = insert(:user)
 
-      insert(:track, spotify_id: "derp", played_at: nil, playing_since: DateTime.utc_now())
+      insert(:track, external_id: "derp", played_at: nil, playing_since: DateTime.utc_now())
 
-      params = params_for(:track, spotify_id: "derp", user_id: me.id)
+      params = params_for(:track, external_id: "derp", user_id: me.id)
 
       assert {:error, %{errors: errors}} = Queue.create_track(params)
-      assert {:spotify_id, {"Already queued", _}} = errors |> Enum.at(0)
+      assert {:external_id, {"Already queued", _}} = errors |> Enum.at(0)
     end
 
     test "can queue same track if it's been played" do
       me = insert(:user)
 
-      insert(:track, spotify_id: "derp", played_at: DateTime.utc_now())
+      insert(:track, external_id: "derp", played_at: DateTime.utc_now())
 
-      params = params_for(:track, spotify_id: "derp", user_id: me.id)
+      params = params_for(:track, external_id: "derp", user_id: me.id)
 
       assert {:ok, track} = Queue.create_track(params)
     end
@@ -90,16 +90,22 @@ defmodule PR.QueueTest do
 
   describe "playing" do
     test "set playing since" do
-      current_track = insert(:track, spotify_id: "derp")
-      assert {:ok, [played: nil, playing: 1]} = Queue.set_current(%SonosItem{spotify_id: "derp"})
+      current_track = insert(:track, external_id: "derp")
+
+      assert {:ok, [played: nil, playing: 1]} =
+               Queue.set_current(%SonosItem{provider: "spotify", external_id: "derp"})
+
       refute Track |> Repo.get(current_track.id) |> Map.get(:playing_since) |> is_nil()
     end
 
     test "set playing since and played at" do
-      previous_track = insert(:track, spotify_id: "herp", playing_since: ~N[2019-01-01 00:00:00])
-      current_track = insert(:track, spotify_id: "derp")
-      assert {:ok, [played: 1, playing: 1]} = Queue.set_current(%SonosItem{spotify_id: "derp"})
-      assert %{spotify_id: "derp"} = Queue.get_playing()
+      previous_track = insert(:track, external_id: "herp", playing_since: ~N[2019-01-01 00:00:00])
+      current_track = insert(:track, external_id: "derp")
+
+      assert {:ok, [played: 1, playing: 1]} =
+               Queue.set_current(%SonosItem{provider: "spotify", external_id: "derp"})
+
+      assert %{external_id: "derp"} = Queue.get_playing()
       refute Track |> Repo.get(previous_track.id) |> Map.get(:played_at) |> is_nil()
       assert Track |> Repo.get(previous_track.id) |> Map.get(:playing_since) |> is_nil()
       refute Track |> Repo.get(current_track.id) |> Map.get(:playing_since) |> is_nil()
@@ -108,7 +114,7 @@ defmodule PR.QueueTest do
     test "nothing is playing" do
       previous_track =
         insert(:track,
-          spotify_id: "herp",
+          external_id: "herp",
           playing_since: ~N[2019-01-01 00:10:00],
           duration: 10_000
         )
@@ -126,22 +132,22 @@ defmodule PR.QueueTest do
     end
 
     # test "nothing is playing but it might be lets give it 10 seconds" do
-    #   track = insert(:recently_playing_track, spotify_id: "herp", duration: 10_000)
+    #   track = insert(:recently_playing_track, external_id: "herp", duration: 10_000)
     #   assert {:ok, [played: 1, playing: nil]} = Queue.set_current(%{})
     #   assert %{played_at: nil, playing_since: nil} = Queue.get_track!(track.id)
     # end
 
     # test "nothing is playing but it might be lets give it 10 seconds its had 10 seconds" do
-    #   previous_track = insert(:playing_track, spotify_id: "herp", duration: 10_000)
+    #   previous_track = insert(:playing_track, external_id: "herp", duration: 10_000)
     #   assert {:ok, [played: nil, playing: nil]} = Queue.set_current(%{})
     #   assert Queue.get_playing() |> is_nil()
     # end
 
     test "already played" do
-      played_track = insert(:track, spotify_id: "herp", played_at: ~N[2019-01-01 00:00:00])
+      played_track = insert(:track, external_id: "herp", played_at: ~N[2019-01-01 00:00:00])
 
       assert {:ok, [played: nil, playing: nil]} =
-               Queue.set_current(%SonosItem{spotify_id: "herp"})
+               Queue.set_current(%SonosItem{provider: "spotify", external_id: "herp"})
 
       assert Queue.get_playing() |> is_nil()
       refute Track |> Repo.get(played_track.id) |> Map.get(:played_at) |> is_nil()
@@ -150,13 +156,13 @@ defmodule PR.QueueTest do
 
     test "same thing already playing" do
       {:ok, playing_since} = ~N[2019-01-01 00:00:00] |> DateTime.from_naive("Etc/UTC")
-      insert(:track, spotify_id: "herple", played_at: ~N[2018-01-01 00:00:00])
-      current_track = insert(:track, spotify_id: "herp", playing_since: playing_since)
+      insert(:track, external_id: "herple", played_at: ~N[2018-01-01 00:00:00])
+      current_track = insert(:track, external_id: "herp", playing_since: playing_since)
 
       assert {:ok, [played: nil, playing: nil]} =
-               Queue.set_current(%SonosItem{spotify_id: "herp"})
+               Queue.set_current(%SonosItem{provider: "spotify", external_id: "herp"})
 
-      assert %{spotify_id: "herp"} = Queue.get_playing()
+      assert %{external_id: "herp"} = Queue.get_playing()
       track = Track |> Repo.get(current_track.id)
       assert track |> Map.get(:played_at) |> is_nil()
       assert DateTime.compare(track.playing_since, playing_since) === :eq

--- a/test/pr_web/controllers/sonos_webhook_controller_test.exs
+++ b/test/pr_web/controllers/sonos_webhook_controller_test.exs
@@ -11,7 +11,7 @@ defmodule PRWeb.SonosWebhookControllerTest do
 
   describe "headers" do
     test "Check group id from header", %{conn: conn} do
-      insert(:track, spotify_id: "0XhXnY0lBzbdEWktDHknsl")
+      insert(:track, external_id: "0XhXnY0lBzbdEWktDHknsl")
       insert(:group, group_id: "RINCON:GROUPID", is_active: true)
 
       capture_log(fn ->
@@ -28,7 +28,7 @@ defmodule PRWeb.SonosWebhookControllerTest do
 
   describe "metadata" do
     test "set current track when there is a next", %{conn: conn} do
-      insert(:track, spotify_id: "0XhXnY0lBzbdEWktDHknsl")
+      insert(:track, external_id: "0XhXnY0lBzbdEWktDHknsl")
       insert(:group, group_id: "RINCON:GROUPID", is_active: true)
 
       conn =
@@ -38,11 +38,11 @@ defmodule PRWeb.SonosWebhookControllerTest do
         |> post(~p"/sonos/callback", CurrentAndNext.json())
 
       assert response(conn, 202)
-      assert %{spotify_id: "0XhXnY0lBzbdEWktDHknsl"} = Queue.get_playing()
+      assert %{external_id: "0XhXnY0lBzbdEWktDHknsl"} = Queue.get_playing()
     end
 
     test "dont handle if group id is different", %{conn: conn} do
-      insert(:track, playing_since: nil, spotify_id: "0XhXnY0lBzbdEWktDHknsl")
+      insert(:track, playing_since: nil, external_id: "0XhXnY0lBzbdEWktDHknsl")
 
       assert capture_log(fn ->
                conn =
@@ -57,7 +57,7 @@ defmodule PRWeb.SonosWebhookControllerTest do
     end
 
     test "set current track when current is already playing", %{conn: conn} do
-      insert(:track, playing_since: DateTime.utc_now(), spotify_id: "0XhXnY0lBzbdEWktDHknsl")
+      insert(:track, playing_since: DateTime.utc_now(), external_id: "0XhXnY0lBzbdEWktDHknsl")
       insert(:group, group_id: "RINCON:GROUPID", is_active: true)
 
       conn =
@@ -67,12 +67,12 @@ defmodule PRWeb.SonosWebhookControllerTest do
         |> post(~p"/sonos/callback", CurrentAndNext.json())
 
       assert response(conn, 202)
-      assert %{spotify_id: "0XhXnY0lBzbdEWktDHknsl"} = Queue.get_playing()
+      assert %{external_id: "0XhXnY0lBzbdEWktDHknsl"} = Queue.get_playing()
     end
 
     test "old track set played", %{conn: conn} do
       insert(:group, group_id: "RINCON:GROUPID", is_active: true)
-      old = insert(:playing_track, spotify_id: "something else")
+      old = insert(:playing_track, external_id: "something else")
 
       conn =
         conn
@@ -87,8 +87,8 @@ defmodule PRWeb.SonosWebhookControllerTest do
 
     test "old track set played update current", %{conn: conn} do
       insert(:group, group_id: "RINCON:GROUPID", is_active: true)
-      old = insert(:playing_track, spotify_id: "something else")
-      new = insert(:track, spotify_id: "0XhXnY0lBzbdEWktDHknsl")
+      old = insert(:playing_track, external_id: "something else")
+      new = insert(:track, external_id: "0XhXnY0lBzbdEWktDHknsl")
 
       conn =
         conn
@@ -97,7 +97,7 @@ defmodule PRWeb.SonosWebhookControllerTest do
         |> post(~p"/sonos/callback", CurrentAndNext.json())
 
       assert response(conn, 202)
-      assert %{spotify_id: "0XhXnY0lBzbdEWktDHknsl"} = Queue.get_playing()
+      assert %{external_id: "0XhXnY0lBzbdEWktDHknsl"} = Queue.get_playing()
       assert %{played_at: %DateTime{}} = Repo.get(Track, old.id)
     end
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -18,7 +18,8 @@ defmodule PR.Factory do
       img: "img",
       played_at: nil,
       playing_since: nil,
-      spotify_id: sequence(:spotify_id, &"spotify:track:#{&1}"),
+      provider: "spotify",
+      external_id: sequence(:external_id, &"track-#{&1}"),
       user: insert(:user)
     }
   end


### PR DESCRIPTION
Groundwork to support more than one streaming service in the queue, with **no behaviour change** (still single-playlist, single-favourite, Spotify-only playback). Prepares for the mixed-provider work described in \`docs/soundcloud-plan.md\`.

## What changed

**Data model**
- Migration renames \`tracks.spotify_id\` -> \`external_id\` and adds a \`provider\` column (default \`spotify\`).
- \`already_queued\` unique index becomes composite \`(provider, external_id)\`.
- The three novelty views are dropped and recreated against \`external_id\`. Migration \`down\` reverses cleanly (verified).

**Provider abstraction**
- New \`PR.Music.Provider\` behaviour (\`search/1\`, \`get_track/1\`, \`replace_playlist/1\`, \`favourite_name/0\`, \`parse_object_id/1\`) plus a registry (\`for/1\`, \`default/0\`, \`match_object_id/1\`).
- \`PR.Music.Provider.Spotify\` implements it, wrapping the existing \`PR.SpotifyAPI\`. The \`spotify:track:\` URI construction and Sonos object-id parsing now live there.
- \`Music\` talks only to the configured provider; \`SonosItem\` resolves provider+external_id via the registry; \`Queue.set_current\` matching is provider-qualified.

**Config**
- \`default_provider: "spotify"\`.

## Out of scope (next steps, see plan)
- SoundCloud API access (paid, needs research) and its provider implementation.
- Run-slicing / favourite-swapping for a genuinely mixed queue.
- Search UI provider toggle.

## Testing
- \`mix test\`: 49 passing.
- Migration up + down verified on a fresh DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)