### PR TITLE
Add SoundCloud OAuth 2.1 (PKCE) auth flow

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,10 @@
       "Bash(fly machines *)",
       "Bash(fly secrets *)",
       "Bash(fly ssh *)",
-      "Bash(fly machine *)"
+      "Bash(fly machine *)",
+      "WebFetch(domain:developers.soundcloud.com)",
+      "Bash(git stash *)",
+      "Bash(gh run *)"
     ]
   }
 }

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -33,6 +33,11 @@ config :pr, :spotify,
   key: System.get_env("SPOTIFY_CLIENT_ID"),
   secret: System.get_env("SPOTIFY_SECRET")
 
+config :pr, :soundcloud,
+  redirect_uri: "#{System.get_env("REDIRECT_URL_BASE")}/soundcloud/authorized",
+  key: System.get_env("SOUNDCLOUD_CLIENT_ID"),
+  secret: System.get_env("SOUNDCLOUD_SECRET")
+
 config :ueberauth, Ueberauth.Strategy.Google.OAuth,
   client_id: System.get_env("GOOGLE_CLIENT_ID"),
   client_secret: System.get_env("GOOGLE_CLIENT_SECRET")
@@ -80,6 +85,8 @@ if config_env() == :prod do
   unless System.get_env("SONOS_SECRET"), do: raise("SONOS_SECRET not available")
   unless System.get_env("SPOTIFY_CLIENT_ID"), do: raise("SPOTIFY_CLIENT_ID not available")
   unless System.get_env("SPOTIFY_SECRET"), do: raise("SPOTIFY_SECRET not available")
+  unless System.get_env("SOUNDCLOUD_CLIENT_ID"), do: raise("SOUNDCLOUD_CLIENT_ID not available")
+  unless System.get_env("SOUNDCLOUD_SECRET"), do: raise("SOUNDCLOUD_SECRET not available")
   unless System.get_env("GOOGLE_CLIENT_ID"), do: raise("GOOGLE_CLIENT_ID not available")
   unless System.get_env("GOOGLE_CLIENT_SECRET"), do: raise("GOOGLE_CLIENT_SECRET not available")
 

--- a/lib/pr/application.ex
+++ b/lib/pr/application.ex
@@ -16,6 +16,7 @@ defmodule PR.Application do
       PR.Ticker,
       PR.SonosAPI,
       PR.SpotifyAPI,
+      PR.SoundCloudAPI,
       PR.Telemetry,
       PRWeb.Endpoint,
       {Phoenix.PubSub, [name: PR.PubSub, adapter: Phoenix.PubSub.PG2]},

--- a/lib/pr/soundcloud_api.ex
+++ b/lib/pr/soundcloud_api.ex
@@ -22,15 +22,10 @@ defmodule PR.SoundCloudAPI do
 
   @spec handle_auth_callback(map(), String.t()) :: {:error, atom()} | {:ok}
   def handle_auth_callback(%{"code" => code}, code_verifier) do
-    Logger.info("SoundCloud callback: verifier present? #{not is_nil(code_verifier)}")
-
-    result =
-      client()
-      |> Client.put_header("accept", "application/json")
-      |> Client.get_token(code: code, code_verifier: code_verifier)
-
-    Logger.info("SoundCloud token exchange result: #{inspect(result)}")
-    handle_token_response(result)
+    client()
+    |> Client.put_header("accept", "application/json")
+    |> Client.get_token(code: code, code_verifier: code_verifier)
+    |> handle_token_response()
   end
 
   @spec gen_code_verifier() :: String.t()

--- a/lib/pr/soundcloud_api.ex
+++ b/lib/pr/soundcloud_api.ex
@@ -22,9 +22,18 @@ defmodule PR.SoundCloudAPI do
 
   @spec handle_auth_callback(map(), String.t()) :: {:error, atom()} | {:ok}
   def handle_auth_callback(%{"code" => code}, code_verifier) do
+    # SoundCloud's authorization_code endpoint authenticates the client from
+    # client_id + client_secret in the request body and ignores the HTTP Basic
+    # header the oauth2 AuthCode strategy sends. It only puts client_id in the
+    # body, so client_secret has to be added explicitly or it returns
+    # invalid_client.
     client()
     |> Client.put_header("accept", "application/json")
-    |> Client.get_token(code: code, code_verifier: code_verifier)
+    |> Client.get_token(
+      code: code,
+      code_verifier: code_verifier,
+      client_secret: get_config(:secret)
+    )
     |> handle_token_response()
   end
 

--- a/lib/pr/soundcloud_api.ex
+++ b/lib/pr/soundcloud_api.ex
@@ -22,10 +22,15 @@ defmodule PR.SoundCloudAPI do
 
   @spec handle_auth_callback(map(), String.t()) :: {:error, atom()} | {:ok}
   def handle_auth_callback(%{"code" => code}, code_verifier) do
-    client()
-    |> Client.put_header("accept", "application/json")
-    |> Client.get_token(code: code, code_verifier: code_verifier)
-    |> handle_token_response()
+    Logger.info("SoundCloud callback: verifier present? #{not is_nil(code_verifier)}")
+
+    result =
+      client()
+      |> Client.put_header("accept", "application/json")
+      |> Client.get_token(code: code, code_verifier: code_verifier)
+
+    Logger.info("SoundCloud token exchange result: #{inspect(result)}")
+    handle_token_response(result)
   end
 
   @spec gen_code_verifier() :: String.t()

--- a/lib/pr/soundcloud_api.ex
+++ b/lib/pr/soundcloud_api.ex
@@ -1,0 +1,58 @@
+defmodule PR.SoundCloudAPI do
+  use PR.Apis.TokenHelper
+  use PR.Apis.EndpointHelper
+
+  alias OAuth2.{Client, Strategy}
+
+  # SoundCloud uses OAuth 2.1, which requires PKCE on the authorization code
+  # flow. The shared TokenHelper auth link/callback do not do PKCE, so those two
+  # steps are implemented here (different arities, so they sit alongside the
+  # macro-generated ones). The code_verifier is generated when the auth link is
+  # built and must be handed back in on the callback.
+
+  @spec get_auth_link!(String.t()) :: String.t()
+  def get_auth_link!(code_challenge) do
+    client()
+    |> Client.put_param(:response_type, "code")
+    |> Client.put_param(:state, "xyz")
+    |> Client.put_param(:code_challenge, code_challenge)
+    |> Client.put_param(:code_challenge_method, "S256")
+    |> Client.authorize_url!()
+  end
+
+  @spec handle_auth_callback(map(), String.t()) :: {:error, atom()} | {:ok}
+  def handle_auth_callback(%{"code" => code}, code_verifier) do
+    client()
+    |> Client.put_header("accept", "application/json")
+    |> Client.get_token(code: code, code_verifier: code_verifier)
+    |> handle_token_response()
+  end
+
+  @spec gen_code_verifier() :: String.t()
+  def gen_code_verifier do
+    :crypto.strong_rand_bytes(64) |> Base.url_encode64(padding: false)
+  end
+
+  @spec code_challenge(String.t()) :: String.t()
+  def code_challenge(verifier) do
+    :crypto.hash(:sha256, verifier) |> Base.url_encode64(padding: false)
+  end
+
+  @spec client() :: Client.t()
+  defp client do
+    Client.new(
+      strategy: Strategy.AuthCode,
+      client_id: get_config(:key),
+      client_secret: get_config(:secret),
+      redirect_uri: get_config(:redirect_uri),
+      grant_type: "authorization_code",
+      site: "https://api.soundcloud.com",
+      authorize_url: "https://secure.soundcloud.com/authorize",
+      token_url: "https://secure.soundcloud.com/oauth/token"
+    )
+  end
+
+  defp get_config(key) do
+    Application.get_env(:pr, :soundcloud)[key]
+  end
+end

--- a/lib/pr_web/controllers/service/service_auth_controller.ex
+++ b/lib/pr_web/controllers/service/service_auth_controller.ex
@@ -3,6 +3,7 @@ defmodule PRWeb.Service.ServiceAuthController do
 
   alias PR.SonosAPI
   alias PR.SpotifyAPI
+  alias PR.SoundCloudAPI
 
   def authorized_sonos(conn, params) do
     case SonosAPI.handle_auth_callback(params) do
@@ -22,6 +23,23 @@ defmodule PRWeb.Service.ServiceAuthController do
     case SpotifyAPI.handle_auth_callback(params) do
       {:ok} ->
         conn
+        |> put_flash(:info, "That worked fine")
+        |> redirect(to: ~p"/setup")
+
+      {:error, _} ->
+        conn
+        |> put_flash(:error, "Didn't work")
+        |> redirect(to: ~p"/setup")
+    end
+  end
+
+  def authorized_soundcloud(conn, params) do
+    verifier = get_session(conn, :soundcloud_code_verifier)
+
+    case SoundCloudAPI.handle_auth_callback(params, verifier) do
+      {:ok} ->
+        conn
+        |> delete_session(:soundcloud_code_verifier)
         |> put_flash(:info, "That worked fine")
         |> redirect(to: ~p"/setup")
 

--- a/lib/pr_web/controllers/service/service_setup_controller.ex
+++ b/lib/pr_web/controllers/service/service_setup_controller.ex
@@ -3,6 +3,7 @@ defmodule PRWeb.Service.ServiceSetupController do
 
   alias PR.SonosAPI
   alias PR.SpotifyAPI
+  alias PR.SoundCloudAPI
   alias PR.SpotifyData
   alias PR.SonosHouseholds
   alias PR.ExternalAuth
@@ -17,8 +18,13 @@ defmodule PRWeb.Service.ServiceSetupController do
     sonos_auth_link = SonosAPI.get_auth_link!()
     spotify_auth_link = SpotifyAPI.get_auth_link!()
 
+    soundcloud_verifier = SoundCloudAPI.gen_code_verifier()
+    soundcloud_auth_link = SoundCloudAPI.get_auth_link!(SoundCloudAPI.code_challenge(soundcloud_verifier))
+    conn = put_session(conn, :soundcloud_code_verifier, soundcloud_verifier)
+
     sonos_token = ExternalAuth.get_auth(SonosAPI)
     spotify_token = ExternalAuth.get_auth(SpotifyAPI)
+    soundcloud_token = ExternalAuth.get_auth(SoundCloudAPI)
 
     has_active_households =
       households
@@ -41,8 +47,10 @@ defmodule PRWeb.Service.ServiceSetupController do
       groups: groups,
       sonos_auth_link: sonos_auth_link,
       spotify_auth_link: spotify_auth_link,
+      soundcloud_auth_link: soundcloud_auth_link,
       has_token_sonos: not is_nil(sonos_token),
       has_token_spotify: not is_nil(spotify_token),
+      has_token_soundcloud: not is_nil(soundcloud_token),
       has_households: [] != households,
       has_groups: [] != groups,
       has_active_households: has_active_households,

--- a/lib/pr_web/controllers/service/service_setup_html/index.html.heex
+++ b/lib/pr_web/controllers/service/service_setup_html/index.html.heex
@@ -4,15 +4,18 @@
     <ol class="setup-list">
       <li>
         <h3>
-          <.check checked={@has_token_sonos and @has_token_spotify} /> Authenticate accounts
+          <.check checked={@has_token_sonos and @has_token_spotify and @has_token_soundcloud} /> Authenticate accounts
         </h3>
-        <%= unless @has_token_sonos and @has_token_spotify do %>
+        <%= unless @has_token_sonos and @has_token_spotify and @has_token_soundcloud do %>
           <p>
             <%= unless @has_token_sonos do %>
               <.link href={@sonos_auth_link} class="button">Authorise Sonos</.link>
             <% end %>
             <%= unless @has_token_spotify do %>
               <.link href={@spotify_auth_link} class="button">Authorise Spotify</.link>
+            <% end %>
+            <%= unless @has_token_soundcloud do %>
+              <.link href={@soundcloud_auth_link} class="button">Authorise SoundCloud</.link>
             <% end %>
           </p>
         <% end %>

--- a/lib/pr_web/router.ex
+++ b/lib/pr_web/router.ex
@@ -79,6 +79,10 @@ defmodule PRWeb.Router do
     pipe_through([:browser])
     get("/sonos/authorized", ServiceAuthController, :authorized_sonos, as: :sonos_auth)
     get("/spotify/authorized", ServiceAuthController, :authorized_spotify, as: :spotify_auth)
+
+    get("/soundcloud/authorized", ServiceAuthController, :authorized_soundcloud,
+      as: :soundcloud_auth
+    )
   end
 
   scope "/sonos", PRWeb.Service do


### PR DESCRIPTION
Wires SoundCloud as a second authorization-code service. OAuth 2.1 requires PKCE, which the shared TokenHelper macro does not do, so the auth link and callback are implemented directly in PR.SoundCloudAPI. The PKCE code_verifier is held in the Plug session between the authorize redirect and the callback.