### PR TITLE
Add setup button to sync queued SoundCloud tracks to the playlist

### DIFF
--- a/lib/pr/queue/queue.ex
+++ b/lib/pr/queue/queue.ex
@@ -78,6 +78,17 @@ defmodule PR.Queue do
     |> Repo.all()
   end
 
+  @spec list_track_uris(String.t()) :: [String.t()]
+  def list_track_uris(provider) do
+    Track
+    |> query_unplayed()
+    |> where([t], t.provider == ^provider)
+    |> order()
+    |> limit(100)
+    |> select([t], {t.external_id})
+    |> Repo.all()
+  end
+
   @spec has_participated?(User.t()) :: boolean()
   def has_participated?(%User{} = user) do
     case Track

--- a/lib/pr_web/controllers/service/service_setup_controller.ex
+++ b/lib/pr_web/controllers/service/service_setup_controller.ex
@@ -8,6 +8,7 @@ defmodule PRWeb.Service.ServiceSetupController do
   alias PR.SonosHouseholds
   alias PR.ExternalAuth
   alias PR.Music
+  alias PR.Queue
   alias PR.SonosHouseholds.GroupManager
 
   def index(conn, _params) do
@@ -137,6 +138,22 @@ defmodule PRWeb.Service.ServiceSetupController do
       {:error, msg} ->
         conn
         |> put_flash(:error, msg)
+        |> redirect(to: ~p"/setup")
+    end
+  end
+
+  def sync_soundcloud_playlist(conn, _) do
+    ids = Queue.list_track_uris("soundcloud") |> Enum.map(fn {id} -> id end)
+
+    case SoundCloudAPI.replace_playlist(ids) do
+      {:ok, _} ->
+        conn
+        |> put_flash(:info, "Synced #{length(ids)} SoundCloud track(s) to the playlist")
+        |> redirect(to: ~p"/setup")
+
+      {:error, reason} ->
+        conn
+        |> put_flash(:error, "SoundCloud sync failed: #{inspect(reason)}")
         |> redirect(to: ~p"/setup")
     end
   end

--- a/lib/pr_web/controllers/service/service_setup_html/index.html.heex
+++ b/lib/pr_web/controllers/service/service_setup_html/index.html.heex
@@ -140,6 +140,12 @@
         <p>
           Sync queue to Spotify playlist, this happens automatically when tracks are added or played.
         </p>
+        <.link href={~p"/setup/sync-soundcloud-playlist"} method="post" class="button">
+          Sync queue to SoundCloud playlist
+        </.link>
+        <p>
+          Push the queued SoundCloud tracks into the playlist set by SOUNDCLOUD_PLAYLIST_ID. Spike tool for verifying SoundCloud sync + Sonos favourite.
+        </p>
       </li>
       <li>
         <h3>Get State</h3>

--- a/lib/pr_web/router.ex
+++ b/lib/pr_web/router.ex
@@ -67,6 +67,7 @@ defmodule PRWeb.Router do
     put("/group/:id", ServiceSetupController, :toggle_group)
     post("/subscribe", ServiceSetupController, :subscribe_sonos_webhooks)
     post("/sync-playlist", ServiceSetupController, :sync_playlist)
+    post("/sync-soundcloud-playlist", ServiceSetupController, :sync_soundcloud_playlist)
     post("/trigger-playlist", ServiceSetupController, :trigger_playlist)
     post("/create-playlist", ServiceSetupController, :create_spotify_playlist)
     post("/bump", ServiceSetupController, :bump)


### PR DESCRIPTION
Spike tooling to verify the fundamental SoundCloud chain before building run-slicing (step 5): can a SoundCloud playlist be edited via the API and mirrored into Sonos as a favourite.

## Changes
- `Queue.list_track_uris/1` - unplayed external_ids filtered by provider.
- `sync_soundcloud_playlist` action + `POST /setup/sync-soundcloud-playlist` route - pushes queued SoundCloud tracks into the playlist via `replace_playlist`.
- "Sync queue to SoundCloud playlist" button in the setup Actions section.

Uses the hardcoded `SOUNDCLOUD_PLAYLIST_ID` config (temporary, until playlist storage + create land in step 8).

## Verification loop (on the deployed env)
1. Create a public SoundCloud playlist owned by the authed account, set `SOUNDCLOUD_PLAYLIST_ID`.
2. Queue SoundCloud tracks via the provider toggle.
3. Hit "Sync queue to SoundCloud playlist" - confirms the `PUT /playlists/{id}` works.
4. Favourite the playlist in Sonos, play it, capture the metadata webhook - confirms the mirror + the `soundcloud:tracks:{id}` object_id.

## Prereqs on the target env
- `SOUNDCLOUD_CLIENT_ID` / `SOUNDCLOUD_SECRET` set (app won't boot otherwise).
- Must have done "Authorise SoundCloud" on that env so a user token exists in its DB - `replace_playlist` needs the user token, and the playlist must be owned by that account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)